### PR TITLE
Github is reporting a security issue with eslint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
   directories:
   - node_modules
 script:
+- npm run lint
 - npm test
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,12 @@ Features: Transforming underscored and dashed selectors to camel-case ones.
 Features: Added `option` to support forcing the transformation to one of two kinds of camelCase styles, including an option to turn this forcing off. This option is:
 - forceCamelStyle: (`lowerCamelCase` | `UpperCamelCase` | `off`)
   - NOTE: the default when no option is provide is `lowerCamelCase` to support backwards compatibility with version `0.1.0`
+
+### 0.3.0
+Upgraded to work with Postcss 8.0 APIs by implementing the `Root()` implementation based on the [migration guide](https://evilmartians.com/chronicles/postcss-8-plugin-migration).
+
+### 0.3.1
+Improved the performance of the plugin by switching from the `Root()` to the `Rule()` Postcss API.
+
+### 0.3.2
+Upgraded `ava`, `eslint` and `eslint-config-postcss` to the latest versions to eliminate a security violation.

--- a/index.js
+++ b/index.js
@@ -1,30 +1,29 @@
 module.exports = function camelcaser(options) {
     options = options || {};
-    var forceCaseStyle = options.forceCaseStyle || 'lowerCamelCase';
+    let forceCaseStyle = options.forceCaseStyle || 'lowerCamelCase';
     return {
         postcssPlugin: 'camelcaser',
         Rule(rule) {
-            var output = rule.selector.replace(/(-|_){1,}\w/g,
-                function (match) {
-                    return match[match.length - 1].toUpperCase();
-                });
+            let output = rule.selector.replace(/(-|_)+\w/g, function (match) {
+                return match[match.length - 1].toUpperCase();
+            });
             switch (forceCaseStyle) {
-            case 'off':
-                break;
-            case 'UpperCamelCase':
-                output = output.replace(/(\W)[a-z]/g, function (match) {
-                    return match.toUpperCase();
-                });
-                break;
-            case 'lowerCamelCase':
-            default:
-                output = output.replace(/(\W)[A-Z]/g, function (match) {
-                    return match.toLowerCase();
-                });
-                break;
+                case 'off':
+                    break;
+                case 'UpperCamelCase':
+                    output = output.replace(/(\W)[a-z]/g, function (match) {
+                        return match.toUpperCase();
+                    });
+                    break;
+                case 'lowerCamelCase':
+                default:
+                    output = output.replace(/(\W)[A-Z]/g, function (match) {
+                        return match.toLowerCase();
+                    });
+                    break;
             }
             rule.selector = output;
-        }
+        },
     };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-camelcaser",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "PostCSS plugin which camelcases all your selectors.",
   "keywords": [
     "postcss",
@@ -20,16 +20,40 @@
     "postcss": "^8.0.4"
   },
   "devDependencies": {
-    "ava": "^0.14.0",
-    "eslint": "^2.10.0",
-    "eslint-config-postcss": "^2.0.2",
+    "@logux/eslint-config": "^41.0.2",
+    "ava": "^3.13.0",
+    "eslint": "^7.11.0",
+    "eslint-config": "^0.3.0",
+    "eslint-config-postcss": "^4.0.0",
+    "eslint-config-standard": "^15.0.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jest": "^24.1.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prefer-let": "^1.1.0",
+    "eslint-plugin-prettierx": "^0.14.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-security": "^1.4.0",
+    "eslint-plugin-standard": "^4.0.2",
+    "eslint-plugin-unicorn": "^23.0.0",
     "postcss": "^8.0.4"
   },
   "scripts": {
-    "test": "ava && eslint *.js"
+    "test": "ava",
+    "lint": "eslint *.js"
   },
   "eslintConfig": {
-    "extends": "eslint-config-postcss/es5"
+    "extends": "eslint-config-postcss",
+    "rules": {
+      "prettierx/options": [
+        "error",
+        {
+          "semi": true,
+          "singleQuote": true
+        }
+      ],
+      "prefer-arrow-callback": "off",
+      "comma-dangle": "off"
+    }
   },
   "publishConfig": {
     "registry": "https://packagecloud.io/freenome/js/npm/"

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
-import postcss from 'postcss';
-import test    from 'ava';
+const test = require('ava');
+const postcss = require('postcss');
 
-import plugin from './';
+const plugin = require('./');
 
 const UPPER_INPUT = '.Camel-case_this{}';
 const LOWER_INPUT = '.camel-case_this{}';
@@ -13,42 +13,43 @@ const FORCE_LOWER = { forceCaseStyle: 'lowerCamelCase' };
 const FORCE_UPPER = { forceCaseStyle: 'UpperCamelCase' };
 const FORCE_OFF = { forceCaseStyle: 'off' };
 
-function run(t, input, output, opts = { }) {
-    return postcss([ plugin(opts) ]).process(input)
-        .then( result => {
+function run(t, input, output, opts = {}) {
+    return postcss([plugin(opts)])
+        .process(input, { from: undefined })
+        .then((result) => {
             t.deepEqual(result.css, output);
             t.deepEqual(result.warnings().length, 0);
         });
 }
 
-test('Transforms UpperInput to camelcase, default options', t=> {
+test('Transforms UpperInput to camelcase, default options', (t) => {
     return run(t, UPPER_INPUT, LOWER_OUTPUT, {});
 });
 
-test('Transforms lowerInput to camelcase, default options', t=> {
+test('Transforms lowerInput to camelcase, default options', (t) => {
     return run(t, LOWER_INPUT, LOWER_OUTPUT, {});
 });
 
-test('Transforms UpperInput to camelcase, forced lower', t=> {
+test('Transforms UpperInput to camelcase, forced lower', (t) => {
     return run(t, UPPER_INPUT, LOWER_OUTPUT, FORCE_LOWER);
 });
 
-test('Transforms lowerInput to camelcase, forced lower', t=> {
+test('Transforms lowerInput to camelcase, forced lower', (t) => {
     return run(t, LOWER_INPUT, LOWER_OUTPUT, FORCE_LOWER);
 });
 
-test('Transforms UpperInput to camelcase, forced Upper', t=> {
+test('Transforms UpperInput to camelcase, forced Upper', (t) => {
     return run(t, UPPER_INPUT, UPPER_OUTPUT, FORCE_UPPER);
 });
 
-test('Transforms lowerInput to camelcase, forced Upper', t=> {
+test('Transforms lowerInput to camelcase, forced Upper', (t) => {
     return run(t, LOWER_INPUT, UPPER_OUTPUT, FORCE_UPPER);
 });
 
-test('Transforms UpperInput to camelcase, forced off', t=> {
+test('Transforms UpperInput to camelcase, forced off', (t) => {
     return run(t, UPPER_INPUT, UPPER_OUTPUT, FORCE_OFF);
 });
 
-test('Transforms lowerInput to camelcase, forced Upper', t=> {
+test('Transforms lowerInput to camelcase, forced off', (t) => {
     return run(t, LOWER_INPUT, LOWER_OUTPUT, FORCE_OFF);
 });


### PR DESCRIPTION
- Bumped version from `0.3.1` to `0.3.2`
- Separated `test` and `lint` scripts, running them both in `.travis.yaml`
- Updated `ava`, `eslint` and `eslint-config-postcss` to the latest version
  - This required adding a bunch of plugins required by `eslint-config-postcss`
  - Which required adding some `rules` for the new `prettierx/options` and a few others to format things better
  - Ran an `eslint -- --fix` to update the `index.js` and `test.js` file
  - The `ava` upgrade required that we switch from `import` to `require` in the `test.js` file
  - Also added `, { from: undefined }` to the postcss `process()` call to eliminate a warning generated by Postcss 8
- Updated the `CHANGELOG.md` to add all of the `0.3.x` versions